### PR TITLE
fix(ci): correct env interpolation; wire Docker vars into CDKTF

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -12,7 +12,6 @@ env:
   IMAGE_NAME: grid
   REGISTRY: ghcr.io/${{ github.repository_owner }}
   IMAGE_TAG: v${{ github.run_number }}-${{ github.sha }}
-  FULL_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
 
 jobs:
   build-and-deploy:
@@ -31,12 +30,12 @@ jobs:
 
       - name: Build Docker image
         run: |
-          docker build -t "${{ env.FULL_IMAGE }}" .
-          docker tag "${{ env.FULL_IMAGE }}" "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          docker build -t "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}" .
+          docker tag "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}" "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
 
       - name: Push Docker image
         run: |
-          docker push "${{ env.FULL_IMAGE }}"
+          docker push "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}"
           docker push "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
 
       - name: Install CDKTF deps
@@ -56,7 +55,7 @@ jobs:
           session_secret    = "${{ secrets.SESSION_SECRET }}"
           eia_api_key       = "${{ secrets.EIA_API_KEY }}"
 
-          docker_image      = "${{ env.FULL_IMAGE }}"
+          docker_image      = "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}"
           docker_username   = "${{ secrets.GHCR_USERNAME || github.actor }}"
           docker_password   = "${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}"
           EOF
@@ -64,4 +63,3 @@ jobs:
       - name: Deploy prod via CDKTF
         working-directory: infrastructure/cdktf
         run: ./scripts/manage-environments.sh deploy prod
-

--- a/infrastructure/cdktf/stacks/ProductionEnvironmentStack.ts
+++ b/infrastructure/cdktf/stacks/ProductionEnvironmentStack.ts
@@ -37,6 +37,26 @@ export class ProductionEnvironmentStack extends TerraformStack {
       sensitive: true,
     });
 
+    // Optional Docker deployment variables (recommended for prod)
+    const dockerImage = new TerraformVariable(this, "docker_image", {
+      type: "string",
+      description: "Fully qualified Docker image (e.g., ghcr.io/owner/repo:tag)",
+      default: "", // empty -> fallback to Git deployment
+    });
+
+    const dockerUsername = new TerraformVariable(this, "docker_username", {
+      type: "string",
+      description: "Registry username for pulling private images",
+      default: "",
+    });
+
+    const dockerPassword = new TerraformVariable(this, "docker_password", {
+      type: "string",
+      description: "Registry token/password for pulling private images",
+      sensitive: true,
+      default: "",
+    });
+
     // Railway builds Docker images automatically from connected repository using Dockerfile
 
     // Create Production Environment
@@ -47,8 +67,10 @@ export class ProductionEnvironmentStack extends TerraformStack {
       postgresPassword: postgresPassword.stringValue,
       sessionSecret: sessionSecret.stringValue,
       eiaApiKey: eiaApiKey.stringValue,
-      
-      // Railway handles Docker build automatically
+      // If docker_image is provided, deploy via Docker; otherwise use Git
+      dockerImage: dockerImage.stringValue || undefined,
+      dockerUsername: dockerUsername.stringValue || undefined,
+      dockerPassword: dockerPassword.stringValue || undefined,
     });
 
     // Data service is not provisioned in prod for now


### PR DESCRIPTION
- Fix workflow error: avoid using env context inside env block; compute image tags inline in steps.\n- Pass docker_image/docker_username/docker_password variables into CDKTF stack so Railway pulls GHCR image.\n\nAfter merge, rerun Deploy Prod workflow on main. This requires secrets:\n- RAILWAY_TOKEN, RAILWAY_PROJECT_ID\n- POSTGRES_PASSWORD, SESSION_SECRET, (optional) EIA_API_KEY\n- GHCR_USERNAME, GHCR_TOKEN (read:packages) for Railway to pull private images.