### PR TITLE
fix(ci): authenticate Railway CLI via config token

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -57,6 +57,10 @@ jobs:
           set -euo pipefail
           echo "Installing Railway CLI..."
           npm i -g @railway/cli || npm i -g railway
+          echo "Seeding Railway CLI auth config..."
+          mkdir -p "$HOME/.config/railway" "$HOME/.railway"
+          printf '{"token":"%s"}' "$RAILWAY_TOKEN" > "$HOME/.config/railway/config.json"
+          cp "$HOME/.config/railway/config.json" "$HOME/.railway/config.json"
           echo "Linking project..."
           railway link --project "$RAILWAY_PROJECT_ID"
           echo "Selecting environment/service..."


### PR DESCRIPTION
Seed the Railway CLI config with RAILWAY_TOKEN before linking the project, so the redeploy step can run non-interactively.\n\n- Write token to ~/.config/railway/config.json and ~/.railway/config.json\n- Then link project and trigger redeploy (with fallbacks)\n\nThis unblocks automatic redeploy after image push.