### PR TITLE
chore(ci): enable Railway API redeploy with guarded CLI fallback

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -57,6 +57,10 @@ jobs:
           set -euo pipefail
           echo "Installing Railway CLI..."
           npm i -g @railway/cli || npm i -g railway
+          echo "Seeding Railway CLI auth config..."
+          mkdir -p "$HOME/.config/railway" "$HOME/.railway"
+          printf '{"token":"%s"}' "$RAILWAY_TOKEN" > "$HOME/.config/railway/config.json"
+          cp "$HOME/.config/railway/config.json" "$HOME/.railway/config.json"
           echo "Linking project..."
           railway link --project "$RAILWAY_PROJECT_ID"
           echo "Selecting environment/service..."

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -14,6 +14,7 @@ env:
   IMAGE_TAG: v${{ github.run_number }}-${{ github.sha }}
   DEPLOY_WITH_CDKTF: 'false'
   RAILWAY_TRIGGER_REDEPLOY: 'true'
+  RAILWAY_USE_API: 'true'
 
 jobs:
   build-and-deploy:
@@ -46,8 +47,8 @@ jobs:
           docker push "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}"
           docker push "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
 
-      - name: Trigger Railway redeploy (registry)
-        if: env.RAILWAY_TRIGGER_REDEPLOY == 'true'
+      - name: Trigger Railway redeploy (registry - CLI)
+        if: env.RAILWAY_TRIGGER_REDEPLOY == 'true' && env.RAILWAY_USE_API != 'true'
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID }}
@@ -77,6 +78,16 @@ jobs:
             railway service restart || railway up --detach
             set -e
           fi
+
+      - name: Trigger Railway redeploy (registry - API)
+        if: env.RAILWAY_TRIGGER_REDEPLOY == 'true' && env.RAILWAY_USE_API == 'true'
+        env:
+          RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
+          RAILWAY_ENVIRONMENT_ID: ${{ secrets.RAILWAY_ENVIRONMENT_ID }}
+          RAILWAY_SERVICE_ID: ${{ secrets.RAILWAY_SERVICE_ID }}
+        run: |
+          node --version
+          node scripts/railway-redeploy.js
 
       - name: Install CDKTF deps
         if: env.DEPLOY_WITH_CDKTF == 'true'

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -14,7 +14,7 @@ env:
   IMAGE_TAG: v${{ github.run_number }}-${{ github.sha }}
   DEPLOY_WITH_CDKTF: 'false'
   RAILWAY_TRIGGER_REDEPLOY: 'true'
-  RAILWAY_USE_API: 'true'
+  RAILWAY_USE_API: 'false'
 
 jobs:
   build-and-deploy:
@@ -48,7 +48,7 @@ jobs:
           docker push "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
 
       - name: Trigger Railway redeploy (registry - CLI)
-        if: env.RAILWAY_TRIGGER_REDEPLOY == 'true' && env.RAILWAY_USE_API != 'true'
+        if: env.RAILWAY_TRIGGER_REDEPLOY == 'true' && (env.RAILWAY_USE_API != 'true' || secrets.RAILWAY_API_TOKEN == '') && secrets.RAILWAY_TOKEN != ''
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID }}
@@ -80,7 +80,7 @@ jobs:
           fi
 
       - name: Trigger Railway redeploy (registry - API)
-        if: env.RAILWAY_TRIGGER_REDEPLOY == 'true' && env.RAILWAY_USE_API == 'true'
+        if: env.RAILWAY_TRIGGER_REDEPLOY == 'true' && env.RAILWAY_USE_API == 'true' && secrets.RAILWAY_API_TOKEN != '' && secrets.RAILWAY_ENVIRONMENT_ID != '' && secrets.RAILWAY_SERVICE_ID != ''
         env:
           RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
           RAILWAY_ENVIRONMENT_ID: ${{ secrets.RAILWAY_ENVIRONMENT_ID }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -48,7 +48,7 @@ jobs:
           docker push "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
 
       - name: Trigger Railway redeploy (registry - CLI)
-        if: env.RAILWAY_TRIGGER_REDEPLOY == 'true' && (env.RAILWAY_USE_API != 'true' || secrets.RAILWAY_API_TOKEN == '' || secrets.RAILWAY_ENVIRONMENT_ID == '' || secrets.RAILWAY_SERVICE_ID == '') && secrets.RAILWAY_TOKEN != ''
+        if: env.RAILWAY_TRIGGER_REDEPLOY == 'true' && (env.RAILWAY_USE_API != 'true' || secrets.RAILWAY_ENVIRONMENT_ID == '' || secrets.RAILWAY_SERVICE_ID == '') && secrets.RAILWAY_TOKEN != ''
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID }}
@@ -80,9 +80,9 @@ jobs:
           fi
 
       - name: Trigger Railway redeploy (registry - API)
-        if: env.RAILWAY_TRIGGER_REDEPLOY == 'true' && env.RAILWAY_USE_API == 'true' && secrets.RAILWAY_API_TOKEN != '' && secrets.RAILWAY_ENVIRONMENT_ID != '' && secrets.RAILWAY_SERVICE_ID != ''
+        if: env.RAILWAY_TRIGGER_REDEPLOY == 'true' && env.RAILWAY_USE_API == 'true' && secrets.RAILWAY_TOKEN != '' && secrets.RAILWAY_ENVIRONMENT_ID != '' && secrets.RAILWAY_SERVICE_ID != ''
         env:
-          RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           RAILWAY_ENVIRONMENT_ID: ${{ secrets.RAILWAY_ENVIRONMENT_ID }}
           RAILWAY_SERVICE_ID: ${{ secrets.RAILWAY_SERVICE_ID }}
         run: |

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -47,8 +47,22 @@ jobs:
           docker push "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}"
           docker push "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
 
+      - name: Resolve redeploy mode flags
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_ENVIRONMENT_ID: ${{ secrets.RAILWAY_ENVIRONMENT_ID }}
+          RAILWAY_SERVICE_ID: ${{ secrets.RAILWAY_SERVICE_ID }}
+        run: |
+          set -euo pipefail
+          HAS_CLI_SECRET=false
+          HAS_API_SECRETS=false
+          if [ -n "${RAILWAY_TOKEN:-}" ]; then HAS_CLI_SECRET=true; fi
+          if [ -n "${RAILWAY_TOKEN:-}" ] && [ -n "${RAILWAY_ENVIRONMENT_ID:-}" ] && [ -n "${RAILWAY_SERVICE_ID:-}" ]; then HAS_API_SECRETS=true; fi
+          echo "HAS_CLI_SECRET=$HAS_CLI_SECRET" >> "$GITHUB_ENV"
+          echo "HAS_API_SECRETS=$HAS_API_SECRETS" >> "$GITHUB_ENV"
+
       - name: Trigger Railway redeploy (registry - CLI)
-        if: env.RAILWAY_TRIGGER_REDEPLOY == 'true' && (env.RAILWAY_USE_API != 'true' || secrets.RAILWAY_ENVIRONMENT_ID == '' || secrets.RAILWAY_SERVICE_ID == '') && secrets.RAILWAY_TOKEN != ''
+        if: ${{ env.RAILWAY_TRIGGER_REDEPLOY == 'true' && (env.RAILWAY_USE_API != 'true' || env.HAS_API_SECRETS != 'true') && env.HAS_CLI_SECRET == 'true' }}
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID }}
@@ -80,7 +94,7 @@ jobs:
           fi
 
       - name: Trigger Railway redeploy (registry - API)
-        if: env.RAILWAY_TRIGGER_REDEPLOY == 'true' && env.RAILWAY_USE_API == 'true' && secrets.RAILWAY_TOKEN != '' && secrets.RAILWAY_ENVIRONMENT_ID != '' && secrets.RAILWAY_SERVICE_ID != ''
+        if: ${{ env.RAILWAY_TRIGGER_REDEPLOY == 'true' && env.RAILWAY_USE_API == 'true' && env.HAS_API_SECRETS == 'true' }}
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           RAILWAY_ENVIRONMENT_ID: ${{ secrets.RAILWAY_ENVIRONMENT_ID }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -14,7 +14,7 @@ env:
   IMAGE_TAG: v${{ github.run_number }}-${{ github.sha }}
   DEPLOY_WITH_CDKTF: 'false'
   RAILWAY_TRIGGER_REDEPLOY: 'true'
-  RAILWAY_USE_API: 'false'
+  RAILWAY_USE_API: 'true'
 
 jobs:
   build-and-deploy:
@@ -48,7 +48,7 @@ jobs:
           docker push "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
 
       - name: Trigger Railway redeploy (registry - CLI)
-        if: env.RAILWAY_TRIGGER_REDEPLOY == 'true' && (env.RAILWAY_USE_API != 'true' || secrets.RAILWAY_API_TOKEN == '') && secrets.RAILWAY_TOKEN != ''
+        if: env.RAILWAY_TRIGGER_REDEPLOY == 'true' && (env.RAILWAY_USE_API != 'true' || secrets.RAILWAY_API_TOKEN == '' || secrets.RAILWAY_ENVIRONMENT_ID == '' || secrets.RAILWAY_SERVICE_ID == '') && secrets.RAILWAY_TOKEN != ''
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID }}

--- a/scripts/railway-redeploy.js
+++ b/scripts/railway-redeploy.js
@@ -1,19 +1,19 @@
 #!/usr/bin/env node
 // Trigger a Railway redeploy via GraphQL API
 // Requires env vars:
-// - RAILWAY_API_TOKEN: Railway API token (Account Settings)
+// - RAILWAY_TOKEN (preferred) or RAILWAY_API_TOKEN: Railway API token (Account Settings)
 // - RAILWAY_ENVIRONMENT_ID: target environment ID
 // - RAILWAY_SERVICE_ID: target service ID
 
 const API_URL = 'https://backboard.railway.app/graphql/v2';
 
 async function main() {
-  const token = process.env.RAILWAY_API_TOKEN;
+  const token = process.env.RAILWAY_API_TOKEN || process.env.RAILWAY_TOKEN;
   const environmentId = process.env.RAILWAY_ENVIRONMENT_ID;
   const serviceId = process.env.RAILWAY_SERVICE_ID;
 
   if (!token) {
-    console.error('Missing RAILWAY_API_TOKEN');
+    console.error('Missing RAILWAY_TOKEN (or RAILWAY_API_TOKEN)');
     process.exit(1);
   }
   if (!environmentId || !serviceId) {
@@ -57,4 +57,3 @@ async function main() {
 }
 
 main();
-

--- a/scripts/railway-redeploy.js
+++ b/scripts/railway-redeploy.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// Trigger a Railway redeploy via GraphQL API
+// Requires env vars:
+// - RAILWAY_API_TOKEN: Railway API token (Account Settings)
+// - RAILWAY_ENVIRONMENT_ID: target environment ID
+// - RAILWAY_SERVICE_ID: target service ID
+
+const API_URL = 'https://backboard.railway.app/graphql/v2';
+
+async function main() {
+  const token = process.env.RAILWAY_API_TOKEN;
+  const environmentId = process.env.RAILWAY_ENVIRONMENT_ID;
+  const serviceId = process.env.RAILWAY_SERVICE_ID;
+
+  if (!token) {
+    console.error('Missing RAILWAY_API_TOKEN');
+    process.exit(1);
+  }
+  if (!environmentId || !serviceId) {
+    console.error('Missing RAILWAY_ENVIRONMENT_ID or RAILWAY_SERVICE_ID');
+    process.exit(1);
+  }
+
+  const query = `
+    mutation ServiceInstanceRedeploy($environmentId: String!, $serviceId: String!) {
+      serviceInstanceRedeploy(environmentId: $environmentId, serviceId: $serviceId)
+    }
+  `;
+
+  const body = JSON.stringify({
+    query,
+    variables: { environmentId, serviceId },
+  });
+
+  try {
+    const res = await fetch(API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+      body,
+    });
+
+    const json = await res.json();
+
+    if (!res.ok || json.errors) {
+      console.error('Railway API error:', JSON.stringify(json.errors || json, null, 2));
+      process.exit(1);
+    }
+
+    console.log('Redeploy triggered:', json.data?.serviceInstanceRedeploy);
+  } catch (err) {
+    console.error('Request failed:', err);
+    process.exit(1);
+  }
+}
+
+main();
+


### PR DESCRIPTION
- Set RAILWAY_USE_API='true' to use Railway GraphQL API for redeploys.\n- Add Resolve flags step to avoid secrets in if-expressions.\n- API path requires: RAILWAY_TOKEN, RAILWAY_ENVIRONMENT_ID, RAILWAY_SERVICE_ID.\n- CLI fallback uses RAILWAY_TOKEN when API secrets are missing.\n\nThis unblocks automatic redeploys after image push while keeping safe fallbacks.