### PR TITLE
fix: simplify Railway CLI usage for CI migrations

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -167,19 +167,15 @@ jobs:
           echo "🔄 Running database migrations on Railway prod environment..."
           echo "📍 Target: Railway service 'web' in 'prod' environment"
           
-          # Install and authenticate Railway CLI
+          # Install Railway CLI
           echo "📦 Installing Railway CLI..."
           npm i -g @railway/cli
           
-          # Authenticate and link to project
-          echo "🔗 Authenticating and linking to Railway project..."
-          railway login --browserless
-          railway link "$RAILWAY_PROJECT_ID"
-          
-          # Execute database migration script on Railway service
-          echo "🚀 Executing database migration script..."
+          # Execute database migration script using Railway CLI with token authentication
+          echo "🚀 Executing database migration script on Railway service..."
+          echo "📍 Using direct service execution (no login required)"
           set +e
-          railway run ./scripts/setup-database.sh --service web --environment prod
+          RAILWAY_TOKEN="$RAILWAY_TOKEN" railway run --service web ./scripts/setup-database.sh
           migration_exit_code=$?
           set -e
           


### PR DESCRIPTION
## Summary
• Remove Railway CLI login step that fails in non-interactive CI environment
• Use RAILWAY_TOKEN directly with railway run command
• Simplify to minimal working approach for automated migrations
• Remove unnecessary project linking that requires interactive authentication

## Test plan
- [x] Verify Railway CLI works with RAILWAY_TOKEN environment variable
- [x] Test direct service execution without login/link steps
- [x] Confirm migration script execution in CI environment

🤖 Generated with [Claude Code](https://claude.ai/code)